### PR TITLE
First version of the Ubuntu router ROCK

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+# Description
+
+Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+## Checklist
+
+- [ ] I have performed a self-review of my own code.
+- [ ] I have made corresponding changes to the documentation.
+- [ ] I have added tests that validate the behaviour of the software.
+- [ ] I validated that new and existing tests pass locally with my changes.
+- [ ] Any dependent changes have been merged and published in downstream modules.

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,17 @@
+name: Build
+
+on:
+  workflow_call:
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - uses: canonical/craft-actions/rockcraft-pack@main
+        id: rockcraft
+      - uses: actions/upload-artifact@v3
+        with:
+          name: rock
+          path: ${{ steps.rockcraft.outputs.rock }}

--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -1,0 +1,14 @@
+name: Push
+
+on:
+  push:
+
+jobs:
+
+  build:
+    uses: ./.github/workflows/build.yaml
+
+  publish:
+    if: github.ref_name == 'main'
+    needs: build
+    uses: ./.github/workflows/publish.yaml

--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -9,6 +9,6 @@ jobs:
     uses: ./.github/workflows/build.yaml
 
   publish:
-    if: github.ref_name == 'main'
+#    if: github.ref_name == 'main'
     needs: build
     uses: ./.github/workflows/publish.yaml

--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -9,6 +9,6 @@ jobs:
     uses: ./.github/workflows/build.yaml
 
   publish:
-#    if: github.ref_name == 'main'
+    if: github.ref_name == 'main'
     needs: build
     uses: ./.github/workflows/publish.yaml

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,41 @@
+name: Publish
+
+on:
+  workflow_call:
+
+jobs:
+
+  publish:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install skopeo
+        run: |
+          sudo snap install --devmode --channel edge skopeo
+      - name: Install yq
+        run: |
+          sudo snap install yq
+      - uses: actions/download-artifact@v3
+        with:
+          name: rock
+
+      - name: Import and push to github package
+        run: |
+          image_name="$(yq '.name' rockcraft.yaml)"
+          version="$(yq '.version' rockcraft.yaml)"
+          rock_file=$(ls *.rock | tail -n 1)
+          sudo skopeo \
+            --insecure-policy \
+            copy \
+            oci-archive:"${rock_file}" \
+            docker-daemon:"ghcr.io/canonical/${image_name}:${version}"
+          docker push ghcr.io/canonical/${image_name}:${version}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v2.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @canonical/telco

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing
+
+## Build and deploy
+
+```bash
+rockcraft pack -v
+sudo skopeo --insecure-policy copy oci-archive:ubuntu-router_0.1_amd64.rock docker-daemon:ubuntu-router:0.1
+docker run ubuntu-router:0.1
+```

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-# ubuntu-router-rock
+# Ubuntu Router ROCK
+
+This container image is used to operate Linux iptables routers.
+
+## Usage
+
+```console
+docker pull ghcr.io/canonical/ubuntu-router:0.1
+docker run -it ghcr.io/canonical/ubuntu-router:0.1
+```

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,0 +1,15 @@
+name: ubuntu-router
+base: ubuntu:22.04
+version: '0.1'
+summary: A Linux router.
+description: |
+    This container image is used to operate Linux iptables routers.
+license: Apache-2.0
+platforms:
+  amd64:
+
+parts:
+  iptables:
+    plugin: nil
+    stage-packages:
+      - iptables


### PR DESCRIPTION
First version of the Ubuntu router ROCK. This container image will be used inside of SD-Core router instead of the old and unmaintained `opencord/quagga` image.